### PR TITLE
Typo fix - platinum / platinium

### DIFF
--- a/charsheet.html
+++ b/charsheet.html
@@ -338,8 +338,8 @@
 
                 <div class="col-xs-12 col-md-12 col-lg-6">
                     <div class="coinType">
-                        <h6>Platinium</h6>
-                        <span class="coin" id="platinium"></span>
+                        <h6>Platinum</h6>
+                        <span class="coin" id="platinum"></span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
There were two references to platinium which now say platinum, I looked around for references to the same word in other files but found nothing.